### PR TITLE
Add check for src field

### DIFF
--- a/rules/RoleRelativePath.py
+++ b/rules/RoleRelativePath.py
@@ -28,8 +28,9 @@ class RoleRelativePath(AnsibleLintRule):
         if 'copy' in play:
             if not isinstance(play['copy'], dict):
                 return False
-            if "../copys" in play['copy']['src']:
-                return ({'sudo': play['copy']},
+            if 'src' in play['copy']:
+                if "../copys" in play['copy']['src']:
+                    return ({'sudo': play['copy']},
                                 self.shortdesc)
         if 'win_copy' in play:
             if not isinstance(play['win_copy'], dict):


### PR DESCRIPTION
Src field can be absent in copy task,
and content field can be used instead,
so we should check if src is present to
avoid Keyerror exception.
