### PR TITLE
Modify rules to support python3 also

### DIFF
--- a/rules/ModuleOctalPermissions.py
+++ b/rules/ModuleOctalPermissions.py
@@ -39,7 +39,7 @@ class ModuleOctalPermissions(AnsibleLintRule):
     def matchtask(self, file, task):
         if task["action"]["__ansible_module__"] in self._modules:
             mode = task['action'].get('mode', None)
-            if isinstance(mode, basestring) and self.mode_regex.match(mode):
+            if isinstance(mode, str) and self.mode_regex.match(mode):
                 return not self.valid_mode_regex.match(mode)
             if isinstance(mode, int):
                 # sensible file permission modes don't

--- a/rules/TaskVariableHasSpace.py
+++ b/rules/TaskVariableHasSpace.py
@@ -8,12 +8,10 @@ class TaskVariableHasSpace(AnsibleLintRule):
     description = ''
     tags = ['task']
 
-    compiled = re.compile(ur'{{(\w*)}}')
+    compiled = re.compile(r'{{(\w*)}}')
 
     def match(self, file, text):
         m = self.compiled.search(text)
         if m:
             return True
         return False
-
-


### PR DESCRIPTION
'basetring' has been replaced by 'str' so behaviour may change in python2 in some corner cases.